### PR TITLE
Ignore useless compiler warning messages

### DIFF
--- a/flycheck-irony.el
+++ b/flycheck-irony.el
@@ -68,7 +68,7 @@
                                    diagnostics)))
               (funcall callback 'finished (delq nil errors)))))))))
 
-(defun flycheck-irony--verify (checker)
+(defun flycheck-irony--verify (_checker)
   "Verify the Flycheck Irony syntax checker."
   (list
    (flycheck-verification-result-new


### PR DESCRIPTION
YouCompleteMe has this piece of comment and code. I think it's quite useful to port it here. I added a variable `flycheck-irony--ignored-error` so we could ignore errors before passing it on to `flycheck`.

> Clang has an annoying warning that shows up when we try to compile header
> files if the header has "#pragma once" inside it. The error is not
> legitimate because it shows up because libclang thinks we are compiling a
> source file instead of a header file.
> 
> See our issue #216 and upstream bug:
>   http://llvm.org/bugs/show_bug.cgi?id=16686
> 
> The second thing we want to filter out are those incredibly annoying "too
> many errors emitted" diagnostics that are utterly useless.
