### PR TITLE
Filter error

### DIFF
--- a/flycheck-irony.el
+++ b/flycheck-irony.el
@@ -68,7 +68,7 @@
                                    diagnostics)))
               (funcall callback 'finished (delq nil errors)))))))))
 
-(defun flycheck-irony--verify (checker)
+(defun flycheck-irony--verify (_checker)
   "Verify the Flycheck Irony syntax checker."
   (list
    (flycheck-verification-result-new

--- a/flycheck-irony.el
+++ b/flycheck-irony.el
@@ -39,6 +39,11 @@
 (eval-when-compile
   (require 'pcase))
 
+(defvar-local flycheck-irony-filter
+  #'identity
+  "Filter all errors before displaying.
+For an example, take a look at `flycheck-dequalify-error-ids`.")
+
 (defun flycheck-irony--build-error (checker buffer diagnostic)
   (let ((severity (irony-diagnostics-severity diagnostic)))
     (if (memq severity '(note warning error fatal))
@@ -91,7 +96,7 @@
   :start #'flycheck-irony--start
   :verify #'flycheck-irony--verify
   :modes irony-supported-major-modes
-  :error-filter #'identity
+  :error-filter flycheck-irony-filter
   :predicate #'(lambda ()
                  irony-mode))
 


### PR DESCRIPTION
Make `error-filter` customizable.

Hi, I'm back! :) Refers to PR #10 

How does this one look. It is `#'identity` by default.
